### PR TITLE
Add `CI Build` and `codecov` badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
+[![Build Status](https://github.com/CSCI-GA-2820-SP24-003/payments/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP24-003/payments/actions)
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP24-003/payments/graph/badge.svg?token=YWXKXD4L0M)](https://codecov.io/gh/CSCI-GA-2820-SP24-003/payments)
 
 This is a skeleton you can use to start your projects
 


### PR DESCRIPTION
Adds the last build and code coverage badges to the `README.md` file.

Requires #47 to be merged first