### PR TITLE
Fix bug where `undefined` is shown after edit in UI

### DIFF
--- a/service/static/js/rest.js
+++ b/service/static/js/rest.js
@@ -213,7 +213,7 @@ async function onSubmitEditPayment(payload) {
     return Notifications.show({ type: "error", message: data.error });
   }
 
-  addSearchResult(payload, true);
+  addSearchResult(data, true);
   modal.close();
   Notifications.show({
     type: "success",


### PR DESCRIPTION
It used to show this after editing the payment method:
![image](https://github.com/CSCI-GA-2820-SP24-003/payments/assets/45975811/a0ff475b-d0bb-4ff1-bc8f-e7d79aafb6ab)

The issue was that it was passing a payload from the edit modal to the results table row. Now it passes the updated method data that is obtained after `PUT` request succeeds.